### PR TITLE
[ec2ssh] Solved syntax error when no ec2 instances.

### DIFF
--- a/bin/ec2ssh
+++ b/bin/ec2ssh
@@ -69,9 +69,9 @@ do
     dnslist+=( ${item[4]} )
     echo -e "\033[36;7m $index \033[m \033[36m${item[2]}\033[m\t${item[0]}\t${item[1]}\t${item[3]}"
     index=$((index + 1))
-    count=$index
   fi
 done
+count=$index
 
 if [ $count -eq 0 ]; then
   echo "Not found EC2 instances"


### PR DESCRIPTION
PR note
---
* When we have no ec2 instances, variable "count" is empty.
* Empty variable cause syntax error.
* I moved count variable substitution to out of "if" code block .